### PR TITLE
EN - add http success handler

### DIFF
--- a/__tests__/httpErrorHandler/httpErrorHandler.test.js
+++ b/__tests__/httpErrorHandler/httpErrorHandler.test.js
@@ -47,7 +47,7 @@ describe('middleware/httpErrorHandler', () => {
       throw new createError(400,'Something missing');
     })
     .use(httpErrorHandler(logger));
-  
+
     handler({}, {}, (event, response) => {
       expect(response).toEqual({
         headers: {},

--- a/__tests__/httpSuccessHandler/httpSuccessHandler.test.js
+++ b/__tests__/httpSuccessHandler/httpSuccessHandler.test.js
@@ -1,0 +1,87 @@
+import middy from 'middy';
+import logger from 'mocks/logger';
+import { httpSuccessHandler } from '../../src';
+
+describe('middleware/httpSuccessHandler', () => {
+  it('should call logger with the correct arguments', (done) => {
+    const handler = middy(async () => {
+      return {
+        headers: {},
+        statusCode: 200,
+        body: {}
+      };
+    });
+    handler.use(httpSuccessHandler(logger))
+    handler({}, {}, () => {
+      expect(logger.info).toHaveBeenCalledWith({
+        response: { headers: {}, body: {}, statusCode: 200 }
+      });
+      done();
+    });
+  });
+
+  it('returns the correct response', (done) => {
+    const handler = middy(async () => {
+      return {
+        headers: {},
+        statusCode: 200,
+        body: { a: 'a' }
+      }
+    });
+    handler.use(httpSuccessHandler(logger))
+    handler({}, {}, (_, response) => {
+      expect(response.statusCode).toBe(200);
+      expect(response.headers).toEqual({});
+      expect(response.body).toEqual(JSON.stringify({ a: 'a' }));
+      done();
+    });
+  });
+
+  describe('when statusCode is not present', () => {
+    it('should default to 200', (done) => {
+      const handler = middy(async () => {
+        return {
+          headers: {},
+          body: { a: 'a' }
+        }
+      });
+      handler.use(httpSuccessHandler(logger))
+      handler({}, {}, (_, response) => {
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toEqual(JSON.stringify({ a: 'a' }));
+        done();
+      });
+    });
+  });
+
+  describe('when there is no body defined', () => {
+    it('should default to 204', (done) => {
+      const handler = middy(async () => {
+        return {
+          headers: {}
+        }
+      });
+      handler.use(httpSuccessHandler(logger))
+      handler({}, {}, (_, response) => {
+        expect(response.statusCode).toBe(204);
+        done();
+      });
+    });
+  });
+
+  describe('when the response is empty', () => {
+    it('should return 204', (done) => {
+      const handler = middy(async () => {
+        return {
+          body: {}
+        };
+      });
+      handler.use(httpSuccessHandler(logger))
+      handler({}, {}, (_, response) => {
+        expect(response.body).toBe(null);
+        expect(response.statusCode).toBe(204);
+        done();
+      });
+    });
+  });
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,5 +1,0 @@
-describe('A simple test', () => {
-  it('works', () => {
-    expect(true).toBeTruthy();
-  });
-});

--- a/src/httpSuccessHandler/httpSuccessHandler.js
+++ b/src/httpSuccessHandler/httpSuccessHandler.js
@@ -1,0 +1,39 @@
+import log from '../utils/log';
+import createError from 'http-errors';
+
+const isEmpty = body => Object.keys(body).length === 0;
+
+const setStatusCode = (handler) => {
+  if (handler.response && handler.response.statusCode && handler.response.body) {
+    return handler.response.statusCode;
+  } else if (!handler.response.body || isEmpty(handler.response.body)) {
+    return 204;
+  } else if (handler.response.body && !handler.response.statusCode) {
+    return 200;
+  }
+};
+
+const safeStringify = (handler, logger) => {
+  if (handler.response.body && !isEmpty(handler.response.body)) {
+    return JSON.stringify(handler.response.body);
+  } else {
+    return null;
+  }
+};
+
+export default logger => (
+  {
+    after: (handler, next) => {
+      const statusCode = setStatusCode(handler);
+      const stringifiedBody = safeStringify(handler, logger);
+      log(logger, { response: { ...handler.response } }, 'info');
+      handler.response = {
+        statusCode,
+        body: stringifiedBody,
+        headers: handler.response.headers
+      };
+
+      return next();
+    }
+  }
+);

--- a/src/httpSuccessHandler/httpSuccessHandler.js
+++ b/src/httpSuccessHandler/httpSuccessHandler.js
@@ -1,5 +1,4 @@
 import log from '../utils/log';
-import createError from 'http-errors';
 
 const isEmpty = body => Object.keys(body).length === 0;
 
@@ -13,7 +12,7 @@ const setStatusCode = (handler) => {
   }
 };
 
-const safeStringify = (handler, logger) => {
+const safeStringify = (handler) => {
   if (handler.response.body && !isEmpty(handler.response.body)) {
     return JSON.stringify(handler.response.body);
   } else {
@@ -25,7 +24,7 @@ export default logger => (
   {
     after: (handler, next) => {
       const statusCode = setStatusCode(handler);
-      const stringifiedBody = safeStringify(handler, logger);
+      const stringifiedBody = safeStringify(handler);
       log(logger, { response: { ...handler.response } }, 'info');
       handler.response = {
         statusCode,

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,5 @@ export { default as dynamodbStreamFilter } from './dynamodbStreamFilter/dynamodb
 export { default as dynamodbStreamParser } from './dynamodbStreamParser/dynamodbStreamParser';
 export { default as ensureJson } from './ensureJson/ensureJson';
 export { default as httpErrorHandler } from './httpErrorHandler/httpErrorHandler';
+export { default as httpSuccessHandler } from './httpSuccessHandler/httpSuccessHandler';
 export { default as s3ErrorHandler } from './s3ErrorHandler/s3ErrorHandler';


### PR DESCRIPTION
## What does it do?

It adds a middleware to handle successful http responses. 

## Features

1. It logs the response using the logger provided to the middleware.
2. It correctly returns 204 when the response body is missing or is an empty object.
3. It defaults to returning a 200 when a status code is not specified.